### PR TITLE
docs: add project README and MIT license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2024 The Celebrity Death Bot contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+# Celebrity Death Bot
+
+Celebrity Death Bot is a Cloudflare Worker that runs on a scheduled Cron trigger. It checks the latest Wikipedia page of notable deaths for the current year and notifies subscribed users when a new entry appears.
+
+## How it works
+
+1. **Fetches Wikipedia**: The worker retrieves `https://en.wikipedia.org/wiki/Deaths_in_<year>` where `<year>` is the current year in the America/New_York timezone.
+2. **Parses entries**: From the page, it extracts each person's name, Wikipedia path, age, description and cause of death.
+3. **Stores in D1**: Entries are stored in a D1 database. Items already in the database are ignored.
+4. **LLM evaluation**: Newly discovered entries are sent to Replicate for LLM evaluation. The worker exposes a webhook to receive callbacks from Replicate.
+5. **Telegram notifications**: When the callback provides results, the worker sends a message via Telegram to the configured chat IDs.
+
+## Configuration
+
+The worker expects the following bindings and environment variables:
+
+- `DB` – D1 database binding used to persist entries.
+- `REPLICATE_API_TOKEN` – API token for Replicate.
+- `TELEGRAM_BOT_TOKEN` – Telegram bot token used for sending messages.
+- `TELEGRAM_CHAT_IDS` – Comma‑separated list of chat IDs to notify.
+- `BASE_URL` – Public URL of the worker, used when building webhook URLs.
+- `REPLICATE_WEBHOOK_SECRET` – Optional secret checked on webhook callbacks.
+
+## Development
+
+Install dependencies and start the development server using Wrangler:
+
+```bash
+npm install
+npm run dev
+```
+
+Deploy the worker with:
+
+```bash
+npm run deploy
+```
+
+## Endpoints
+
+- `POST /run` – Manually trigger the job.
+- `POST /replicate/callback` – Endpoint for Replicate webhook callbacks.
+- `GET /health` – Simple health check returning `ok`.
+
+## License
+
+This project is licensed under the [MIT License](LICENSE.md).
+


### PR DESCRIPTION
## Summary
- document how the worker fetches and processes Wikipedia death entries
- add MIT license for project

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689fd33bc14883298c36cd76773b5664