### PR TITLE
Increase Replicate token limit

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -162,7 +162,7 @@ async function callReplicate(env: Env, prompt: string) {
         "Return only valid JSON or an empty JSON object as instructed. No extra commentary.",
       verbosity: "low",
       reasoning_effort: "minimal",
-      max_completion_tokens: 800,
+      max_completion_tokens: 4096,
     },
     webhook: env.REPLICATE_WEBHOOK_SECRET
       ? `${env.BASE_URL}/replicate/callback?secret=${encodeURIComponent(


### PR DESCRIPTION
## Summary
- raise Replicate `max_completion_tokens` to 4096 for longer responses

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a075166a988329be95689746ad8e6f