### PR TITLE
Require secret for manual run endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The worker expects the following bindings and environment variables:
 - `TELEGRAM_CHAT_IDS` – Comma‑separated list of chat IDs to notify.
 - `BASE_URL` – Public URL of the worker, used when building webhook URLs.
 - `REPLICATE_WEBHOOK_SECRET` – Optional secret checked on webhook callbacks.
+- `MANUAL_RUN_SECRET` – Secret token required to call the manual `/run` endpoint.
 
 ## Development
 
@@ -38,7 +39,7 @@ npm run deploy
 
 ## Endpoints
 
-- `POST /run` – Manually trigger the job.
+- `POST /run?secret=<token>` – Manually trigger the job. Requires `MANUAL_RUN_SECRET`.
 - `POST /replicate/callback` – Endpoint for Replicate webhook callbacks.
 - `GET /health` – Simple health check returning `ok`.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export interface Env {
   TELEGRAM_CHAT_IDS: string; // comma-separated chat IDs: "111,222,333"
   BASE_URL: string; // e.g. "https://your-worker.your-subdomain.workers.dev"
   REPLICATE_WEBHOOK_SECRET?: string; // optional: extra safety on callback
+  MANUAL_RUN_SECRET: string; // secret required for manual /run endpoint
 }
 
 type DeathEntry = {
@@ -410,6 +411,10 @@ export default {
 
     // Manual trigger for testing
     if (pathname === "/run" && request.method === "POST") {
+      const s = url.searchParams.get("secret");
+      if (s !== env.MANUAL_RUN_SECRET) {
+        return new Response("Unauthorized", { status: 401 });
+      }
       try {
         const res = await runJob(env);
         return Response.json({ ok: true, ...res });


### PR DESCRIPTION
## Summary
- require `secret` query parameter on `/run` endpoint matching `MANUAL_RUN_SECRET`
- document and type new `MANUAL_RUN_SECRET` env variable

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a0e8a58cf483299c72f9f88e0cf1ca