### PR TITLE
refactor: externalize Replicate prompt

### DIFF
--- a/public/replicate-prompt.txt
+++ b/public/replicate-prompt.txt
@@ -1,0 +1,1 @@
+Extract from this list any names that an American might know. Include NFL, NBA, and MLB players, people from the entertainment industry, pop culture, popular music, TV shows, movies and commercials. Structure the result as a JSON file with fields "name", "age", "description" and "cause of death". If no matches are found, return an empty Json structure with no fields.


### PR DESCRIPTION
## Summary
- load Replicate prompt text from `public/replicate-prompt.txt`
- add `ASSETS` binding to `Env` and build prompt asynchronously

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a1deef95408329b68a3a638a23f6df