### PR TITLE
Use Authorization header for manual run

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The worker expects the following bindings and environment variables:
 - `TELEGRAM_CHAT_IDS` – Comma‑separated list of chat IDs to notify.
 - `BASE_URL` – Public URL of the worker, used when building webhook URLs.
 - `REPLICATE_WEBHOOK_SECRET` – Optional secret checked on webhook callbacks.
-- `MANUAL_RUN_SECRET` – Secret token required to call the manual `/run` endpoint.
+- `MANUAL_RUN_SECRET` – Bearer token required to call the manual `/run` endpoint. Send it via the `Authorization` header.
 
 ## Development
 
@@ -43,7 +43,13 @@ npm run deploy
 
 ## Endpoints
 
-- `POST /run?secret=<token>` – Manually trigger the job. Requires `MANUAL_RUN_SECRET`.
+- `POST /run` – Manually trigger the job. Requires `MANUAL_RUN_SECRET` sent as `Authorization: Bearer <token>`.
+  Example:
+
+  ```bash
+  curl -X POST https://your-worker.example.com/run \
+       -H "Authorization: Bearer $MANUAL_RUN_SECRET"
+  ```
 - `POST /replicate/callback` – Endpoint for Replicate webhook callbacks.
 - `GET /health` – Simple health check returning `ok`.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,12 +2,13 @@ export interface Env {
   DB: D1Database;
 
   // Secrets / Vars
+  ASSETS: { fetch: typeof fetch };
   REPLICATE_API_TOKEN: string;
   TELEGRAM_BOT_TOKEN: string;
   TELEGRAM_CHAT_IDS: string; // comma-separated chat IDs: "111,222,333"
   BASE_URL: string; // e.g. "https://your-worker.your-subdomain.workers.dev"
   REPLICATE_WEBHOOK_SECRET?: string; // optional: extra safety on callback
-  MANUAL_RUN_SECRET: string; // secret required for manual /run endpoint
+  MANUAL_RUN_SECRET: string; // bearer token required for manual /run endpoint
 }
 
 type DeathEntry = {
@@ -411,8 +412,9 @@ export default {
 
     // Manual trigger for testing
     if (pathname === "/run" && request.method === "POST") {
-      const s = url.searchParams.get("secret");
-      if (s !== env.MANUAL_RUN_SECRET) {
+      const auth = request.headers.get("Authorization");
+      const expected = `Bearer ${env.MANUAL_RUN_SECRET}`;
+      if (auth !== expected) {
         return new Response("Unauthorized", { status: 401 });
       }
       try {


### PR DESCRIPTION
## Summary
- secure the `/run` endpoint by validating a Bearer token from the `Authorization` header instead of a query parameter
- document new header-based authentication for manual runs and provide a curl example
- add missing `ASSETS` binding to `Env` for type completeness

## Testing
- `npm test` (fails: Missing script "test")
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68a1ecfc219083298ee5658b82555506