### PR TITLE
fix(db): use D1 batch API; respect SQLite param limits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "celebrity-death-bot",
-	"version": "0.0.0",
+	"version": "1.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "celebrity-death-bot",
-			"version": "0.0.0",
+			"version": "1.0.0",
 			"devDependencies": {
 				"typescript": "^5.5.2",
 				"wrangler": "^4.30.0"
@@ -26,9 +26,9 @@
 			}
 		},
 		"node_modules/@cloudflare/unenv-preset": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.6.1.tgz",
-			"integrity": "sha512-48rC6jo9CkSRkImfu5KU4zKyoPJx7b9GTUpZn0Emr6J+jkmrLhwCY3BI10QS+fhOt1NkJNlxIcYrBgvWeCpKOw==",
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.6.2.tgz",
+			"integrity": "sha512-C7/tW7Qy+wGOCmHXu7xpP1TF3uIhRoi7zVY7dmu/SOSGjPilK+lSQ2lIRILulZsT467ZJNlI0jBxMbd8LzkGRg==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"peerDependencies": {
@@ -42,9 +42,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-64": {
-			"version": "1.20250813.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250813.0.tgz",
-			"integrity": "sha512-Pka37/jqLy7ZaQlwpBy79A/BLH+qpRPSEX2h/zWND+qRfoCVCCaZQPdknHZO0pcvHPzK8E2Z4j5QI1IafPA5UA==",
+			"version": "1.20250816.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250816.0.tgz",
+			"integrity": "sha512-yN1Rga4ufTdrJPCP4gEqfB47i1lWi3teY5IoeQbUuKnjnCtm4pZvXur526JzCmaw60Jx+AEWf5tizdwRd5hHBQ==",
 			"cpu": [
 				"x64"
 			],
@@ -59,9 +59,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20250813.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250813.0.tgz",
-			"integrity": "sha512-QnaJbmhcA32+4uZ+or1hXZjdxGqrFUuh6Ye+skEGu3iB/xzq9CmyVyoKoshiUOcWGKndQb7KRo56dq0bVvVLFw==",
+			"version": "1.20250816.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250816.0.tgz",
+			"integrity": "sha512-WyKPMQhbU+TTf4uDz3SA7ZObspg7WzyJMv/7J4grSddpdx2A4Y4SfPu3wsZleAOIMOAEVi0A1sYDhdltKM7Mxg==",
 			"cpu": [
 				"arm64"
 			],
@@ -76,9 +76,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-64": {
-			"version": "1.20250813.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250813.0.tgz",
-			"integrity": "sha512-6pokgBQmujJsAuqOme2wBX5ol/1YW3d7kV7wp0Y1/tFi46TnmWcEy08B4FD5t2AARQJ68a7XMxIJKWChcaJ9Cg==",
+			"version": "1.20250816.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250816.0.tgz",
+			"integrity": "sha512-NWHOuFnVBaPRhLHw8kjPO9GJmc2P/CTYbnNlNm0EThyi57o/oDx0ldWLJqEHlrdEPOw7zEVGBqM/6M+V9agC6w==",
 			"cpu": [
 				"x64"
 			],
@@ -93,9 +93,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-arm64": {
-			"version": "1.20250813.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250813.0.tgz",
-			"integrity": "sha512-lFwqohi8fkR98OwjHT69sbThx4BJem7vu6N8kqrge7wuKJWrMDNbzOTdyBA8adV9DmE07ELuN2vcbbu8ZjaL2Q==",
+			"version": "1.20250816.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250816.0.tgz",
+			"integrity": "sha512-FR+/yhaWs7FhfC3GKsM3+usQVrGEweJ9qyh7p+R6HNwnobgKr/h5ATWvJ4obGJF6ZHHodgSe+gOSYR7fkJ1xAQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -110,9 +110,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-windows-64": {
-			"version": "1.20250813.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250813.0.tgz",
-			"integrity": "sha512-Fs62NvUajtoXb+4W8jaRXzw64Nbmb8X+PbRLZbxUFv68sGhxKPw1nB1YEmNNZ215ma47hTlSdF3UQh4FOmz7NA==",
+			"version": "1.20250816.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250816.0.tgz",
+			"integrity": "sha512-0lqClj2UMhFa8tCBiiX7Zhd5Bjp0V+X8oNBG6V6WsR9p9/HlIHAGgwRAM7aYkyG+8KC8xlbC89O2AXUXLpHx0g==",
 			"cpu": [
 				"x64"
 			],
@@ -1258,9 +1258,9 @@
 			}
 		},
 		"node_modules/miniflare": {
-			"version": "4.20250813.1",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20250813.1.tgz",
-			"integrity": "sha512-6PyXwR4pZmH9ukO0jR5LmhlFVMktsVVGVcUjD9Lpev5QwnqjTRPEv73cnXCe0+oTbIm5TYnvXsAklaWxQuxstA==",
+			"version": "4.20250816.0",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20250816.0.tgz",
+			"integrity": "sha512-HuakGvmsU8aC60wsHP7Su+BgJFly1GmKbmbR/nqIz0Xlk6wcd/pp3vZ7jtbT3unf+aeBOlEO/CzcUb8xFsJLdA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1272,7 +1272,7 @@
 				"sharp": "^0.33.5",
 				"stoppable": "1.1.0",
 				"undici": "^7.10.0",
-				"workerd": "1.20250813.0",
+				"workerd": "1.20250816.0",
 				"ws": "8.18.0",
 				"youch": "4.1.0-beta.10",
 				"zod": "3.22.3"
@@ -1380,9 +1380,9 @@
 			}
 		},
 		"node_modules/supports-color": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.1.0.tgz",
-			"integrity": "sha512-GBuewsPrhJPftT+fqDa9oI/zc5HNsG9nREqwzoSFDOIqf0NggOZbHQj2TE1P1CDJK8ZogFnlZY9hWoUiur7I/A==",
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.0.tgz",
+			"integrity": "sha512-5eG9FQjEjDbAlI5+kdpdyPIBMRH4GfTVDGREVupaZHmVoppknhM29b/S9BkQz7cathp85BVgRi/As3Siln7e0Q==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1422,9 +1422,9 @@
 			"license": "MIT"
 		},
 		"node_modules/undici": {
-			"version": "7.13.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.13.0.tgz",
-			"integrity": "sha512-l+zSMssRqrzDcb3fjMkjjLGmuiiK2pMIcV++mJaAc9vhjSGpvM7h43QgP+OAMb1GImHmbPyG2tBXeuyG5iY4gA==",
+			"version": "7.14.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.14.0.tgz",
+			"integrity": "sha512-Vqs8HTzjpQXZeXdpsfChQTlafcMQaaIwnGwLam1wudSSjlJeQ3bw1j+TLPePgrCnCpUXx7Ba5Pdpf5OBih62NQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1446,9 +1446,9 @@
 			}
 		},
 		"node_modules/workerd": {
-			"version": "1.20250813.0",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250813.0.tgz",
-			"integrity": "sha512-bDlPGSnb/KESpGFE57cDjgP8mEKDM4WBTd/uGJBsQYCB6Aokk1eK3ivtHoxFx3MfJNo3v6/hJy6KK1b6rw1gvg==",
+			"version": "1.20250816.0",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250816.0.tgz",
+			"integrity": "sha512-5gIvHPE/3QVlQR1Sc1NdBkWmqWj/TSgIbY/f/qs9lhiLBw/Da+HbNBTVYGjvwYqEb3NQ+XQM4gAm5b2+JJaUJg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
@@ -1459,28 +1459,28 @@
 				"node": ">=16"
 			},
 			"optionalDependencies": {
-				"@cloudflare/workerd-darwin-64": "1.20250813.0",
-				"@cloudflare/workerd-darwin-arm64": "1.20250813.0",
-				"@cloudflare/workerd-linux-64": "1.20250813.0",
-				"@cloudflare/workerd-linux-arm64": "1.20250813.0",
-				"@cloudflare/workerd-windows-64": "1.20250813.0"
+				"@cloudflare/workerd-darwin-64": "1.20250816.0",
+				"@cloudflare/workerd-darwin-arm64": "1.20250816.0",
+				"@cloudflare/workerd-linux-64": "1.20250816.0",
+				"@cloudflare/workerd-linux-arm64": "1.20250816.0",
+				"@cloudflare/workerd-windows-64": "1.20250816.0"
 			}
 		},
 		"node_modules/wrangler": {
-			"version": "4.30.0",
-			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.30.0.tgz",
-			"integrity": "sha512-NXJUObuXxgG8/ChQ4yXkWLmDQ5ZcO98gyq1yFKYVntJ884C0IpDQrVnAv2RA0ZEz5eB8zal+4OKnr26P3N7ItA==",
+			"version": "4.31.0",
+			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.31.0.tgz",
+			"integrity": "sha512-blb8NfA4BGscvSzvLm2mEQRuUTmaMCiglkqHiR3EIque78UXG39xxVtFXlKhK32qaVvGI7ejdM//HC9plVPO3w==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"dependencies": {
 				"@cloudflare/kv-asset-handler": "0.4.0",
-				"@cloudflare/unenv-preset": "2.6.1",
+				"@cloudflare/unenv-preset": "2.6.2",
 				"blake3-wasm": "2.1.5",
 				"esbuild": "0.25.4",
-				"miniflare": "4.20250813.1",
+				"miniflare": "4.20250816.0",
 				"path-to-regexp": "6.3.0",
 				"unenv": "2.0.0-rc.19",
-				"workerd": "1.20250813.0"
+				"workerd": "1.20250816.0"
 			},
 			"bin": {
 				"wrangler": "bin/wrangler.js",
@@ -1493,7 +1493,7 @@
 				"fsevents": "~2.3.2"
 			},
 			"peerDependencies": {
-				"@cloudflare/workers-types": "^4.20250813.0"
+				"@cloudflare/workers-types": "^4.20250816.0"
 			},
 			"peerDependenciesMeta": {
 				"@cloudflare/workers-types": {

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -28,35 +28,36 @@ export async function insertBatchReturningNew(env: Env, rows: DeathEntry[]): Pro
     r.cause ?? null,
   ] as const);
 
-  // 5 params per row -> keep well under 999
-  const CHUNK = 480;
+  // 5 params per row -> SQLite has a 999 parameter limit. 199*5=995
+  const CHUNK = 199;
   const newOnes: DeathEntry[] = [];
 
-  // Begin transaction
-  await env.DB.prepare('BEGIN').run();
-  try {
-    for (let i = 0; i < tuples.length; i += CHUNK) {
-      const chunk = tuples.slice(i, i + CHUNK);
-      const placeholders = chunk
-        .map((_, j) => `(?${j * 5 + 1},?${j * 5 + 2},?${j * 5 + 3},?${j * 5 + 4},?${j * 5 + 5})`)
-        .join(',');
+  // Use D1's batch API which runs statements in a transaction.
+  const statements: D1PreparedStatement[] = [];
+  for (let i = 0; i < tuples.length; i += CHUNK) {
+    const chunk = tuples.slice(i, i + CHUNK);
+    const placeholders = chunk
+      .map((_, j) => `(?${j * 5 + 1},?${j * 5 + 2},?${j * 5 + 3},?${j * 5 + 4},?${j * 5 + 5})`)
+      .join(',');
 
-      const sql = `
-        INSERT INTO deaths (name, wiki_path, age, description, cause, llm_result)
-        SELECT v.name, v.wiki_path, v.age, v.description, v.cause, 'no'
-        FROM (VALUES ${placeholders}) AS v(name, wiki_path, age, description, cause)
-        ON CONFLICT(wiki_path) DO NOTHING
-        RETURNING name, wiki_path, age, description, cause
-      `;
+    const sql = `
+      INSERT INTO deaths (name, wiki_path, age, description, cause, llm_result)
+      SELECT v.name, v.wiki_path, v.age, v.description, v.cause, 'no'
+      FROM (VALUES ${placeholders}) AS v(name, wiki_path, age, description, cause)
+      ON CONFLICT(wiki_path) DO NOTHING
+      RETURNING name, wiki_path, age, description, cause
+    `;
 
-      const flatBinds = chunk.flat();
-      const res = await env.DB.prepare(sql).bind(...flatBinds).all<DeathEntry>();
-      if (res.results?.length) newOnes.push(...(res.results as any));
+    const flatBinds = chunk.flat();
+    statements.push(env.DB.prepare(sql).bind(...flatBinds));
+  }
+
+  if (statements.length) {
+    const results = await env.DB.batch<DeathEntry>(statements);
+    for (const r of results) {
+      const rows = (r as any).results as DeathEntry[] | undefined;
+      if (rows && rows.length) newOnes.push(...rows);
     }
-    await env.DB.prepare('COMMIT').run();
-  } catch (err) {
-    await env.DB.prepare('ROLLBACK').run();
-    throw err;
   }
 
   return newOnes;


### PR DESCRIPTION
 - Summary: Replace manual BEGIN/COMMIT/ROLLBACK with env.DB.batch(...) to comply with D1. Adjust batch size to 199 rows (995 params) to stay
under SQLite’s 999 param limit.
    - Why: Fixes D1_ERROR about SQL transactions and avoids param overflow; keeps returning newly inserted rows.
    - How to verify:
    - `npm start` locally
    - `curl -X POST "$BASE_URL/run" -H "Authorization: Bearer $MANUAL_RUN_SECRET"`
    - Confirm no D1 transaction errors and new rows are inserted/queued.
- Notes: If cron still shows “exceededCpu”, consider profiling parsing or reducing fetch timeouts.