### PR TITLE
Update privacy policy

### DIFF
--- a/public/privacy.html
+++ b/public/privacy.html
@@ -25,29 +25,32 @@
     <header>
       <h1>Privacy Policy — CelebrityDeathBot</h1>
       <div class="muted">Effective date:
-        <time datetime="2025-08-16">August 16, 2025</time>
+        <time datetime="2025-08-24">August 24, 2025</time>
       </div>
     </header>
 
-    <p>CelebrityDeathBot (“the Bot”) sends Telegram updates when a celebrity dies. We designed the Bot to collect as little information as possible.</p>
+    <p>CelebrityDeathBot (“the Service”) includes a public website and a Telegram bot that posts updates when a celebrity dies. We designed the Service to collect as little information as possible.</p>
+    <p>This policy covers: (a) the public website served by our Cloudflare Worker, (b) the Telegram bot, and (c) any official social accounts such as X/Twitter posts. Platform-specific policies (e.g., Telegram or X/Twitter) continue to apply when you use those platforms.</p>
 
     <section class="summary" aria-label="Summary">
       <ul>
-        <li>We only store your <strong>numeric Telegram user ID</strong>.</li>
-        <li>We use it <strong>solely</strong> to send you the updates you requested.</li>
-        <li>We do <strong>not</strong> store your name, username, phone number, profile photo, message contents, or other personal data.</li>
-        <li>We do <strong>not</strong> sell or share your data for advertising.</li>
+        <li><strong>Telegram:</strong> We store only your <strong>numeric Telegram user ID</strong> to deliver notifications.</li>
+        <li><strong>Website:</strong> We keep <strong>basic access logs</strong> (e.g., IP address, user agent, requested path, timestamp) for up to <strong>30 days</strong> for operations and security.</li>
+        <li><strong>X/Twitter:</strong> Your use of X/Twitter is governed by their privacy policy; we do <strong>not</strong> keep additional personal information about your X/Twitter account.</li>
+        <li>We do <strong>not</strong> sell your data or use it for advertising.</li>
       </ul>
     </section>
 
     <h2>Data We Collect</h2>
-    <p><strong>Telegram user ID (numeric):</strong> Stored to manage your subscription and deliver notifications.</p>
-    <p>That’s it. We do not intentionally collect or store any other information.</p>
+    <p><strong>Telegram:</strong> We store your <strong>numeric Telegram user ID</strong> to manage your subscription and deliver notifications. We do not store your name, username, phone number, profile photo, or message contents.</p>
+    <p><strong>Website:</strong> When you access our website, our infrastructure records <em>basic access logs</em> such as IP address, user agent, requested URL/path, and timestamp. These logs help us operate the site, detect abuse, and investigate outages.</p>
+    <p><strong>X/Twitter:</strong> Interactions with our posts or account are covered by X/Twitter’s own privacy policy. We do not collect or maintain additional personal information about your X/Twitter account beyond what is publicly visible on the platform.</p>
 
     <h2>How We Use Your Data</h2>
     <ul>
-      <li><strong>Deliver notifications:</strong> Use your user ID to send updates through Telegram.</li>
-      <li><strong>Manage subscription state:</strong> Determine whether you are subscribed or unsubscribed.</li>
+      <li><strong>Deliver notifications (Telegram):</strong> Use your user ID to send updates through Telegram.</li>
+      <li><strong>Manage subscription state (Telegram):</strong> Determine whether you are subscribed or unsubscribed.</li>
+      <li><strong>Operate and secure the website:</strong> Use basic access logs to keep the site reliable, troubleshoot problems, and mitigate abuse.</li>
     </ul>
 
     <h2>Legal Basis (EEA/UK users)</h2>
@@ -55,8 +58,9 @@
 
     <h2>Data Retention</h2>
     <ul>
-      <li>We keep your user ID while you are subscribed.</li>
-      <li>If you unsubscribe (e.g., by sending <code>/stop</code>) or request deletion, we delete your user ID from our system.</li>
+      <li><strong>Telegram:</strong> We keep your user ID while you are subscribed. If you unsubscribe (e.g., by sending <code>/stop</code>) or request deletion, we delete your user ID from our system.</li>
+      <li><strong>Website:</strong> Basic access logs are retained for up to <strong>30 days</strong> and then deleted or aggregated.</li>
+      <li><strong>X/Twitter:</strong> We do not keep additional personal information beyond what is publicly visible on the platform.</li>
     </ul>
 
     <h2>Sharing &amp; Disclosure</h2>
@@ -71,14 +75,14 @@
     </ul>
 
     <h2>Security</h2>
-    <p>We take reasonable technical and organizational measures to protect your user ID against unauthorized access, alteration, or deletion.</p>
+    <p>We take reasonable technical and organizational measures to protect data against unauthorized access, alteration, or deletion, appropriate to the nature of the data (e.g., Telegram user IDs, basic access logs).</p>
 
     <h2>International Transfers</h2>
     <p>Your user ID may be processed in the country where our infrastructure is located. We use reputable providers and apply safeguards appropriate to the transfer.</p>
 
     <h2>Your Rights</h2>
     <p>Depending on your location, you may have rights to access, delete, or object to processing/withdraw consent.</p>
-    <p><strong>How to exercise:</strong> Send <code>/stop</code> in the Bot to unsubscribe (removes your user ID from the active list), or contact us (see below) and include your numeric Telegram user ID so we can locate and remove it.</p>
+    <p><strong>How to exercise:</strong> For Telegram, send <code>/stop</code> in the Bot to unsubscribe (removes your user ID from the active list), or contact us (see below) and include your numeric Telegram user ID so we can locate and remove it. For website logs, please contact us; note these logs are retained only briefly (up to 30 days).</p>
 
     <h2>Children’s Privacy</h2>
     <p>The Bot is not intended for use by children under 13 (or the age required by local law). We do not knowingly collect data from children.</p>
@@ -96,7 +100,8 @@
 
     <hr />
     <footer>
-      This policy describes data handling by CelebrityDeathBot. Your use of Telegram is governed by Telegram’s own terms and privacy policy.
+      This policy describes data handling by CelebrityDeathBot’s website, Telegram bot, and related social posts.
+      Your use of Telegram is governed by Telegram’s terms and privacy policy; your use of X/Twitter is governed by X/Twitter’s terms and privacy policy.
     </footer>
   </main>
 </body>


### PR DESCRIPTION
This PR updates the public privacy policy to cover the full service, not just Telegram.\n\nChanges\n- Clarifies
scope: site (Cloudflare Worker), Telegram bot, and X/Twitter posts\n- Website: basic access logs (IP, UA, path,
timestamp) kept up to 30 days for ops/security\n- Telegram: only numeric user ID stored for delivery and subscription
state\n- X/Twitter: governed by X/Twitter’s privacy policy; no additional data stored\n- Updated effective date to
2025-08-24\n\nVerification\n- Run locally (`npm start`) and visit /privacy to review content and links\n- No schema or
config changes; docs-only change\n\nNotes\n- No secrets, no build changes, no migrations.