### PR TITLE
Add manual X posting controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ The worker expects the following bindings and environment variables:
   - `X_CLIENT_ID` – OAuth 2.0 client ID for your X App
   - `X_CLIENT_SECRET` – (optional) client secret; included when present
   - `X_ENC_KEY` – base64 AES-256-GCM key to encrypt tokens in D1
+  - `POST_TO_X` – Set to `true` to automatically post approved deaths to X. Missing or any other value disables automatic X posting.
+  - `X_POST_INCLUDE_WIKIPEDIA_LINK` – Set to `true` to append Wikipedia links to automatic X posts. Missing or any other value omits the link.
 
 When connected once via OAuth 2.0, the worker stores and refreshes tokens and posts via `POST /2/tweets` with a Bearer token.
 
@@ -215,7 +217,10 @@ Notes
 
 The worker can post each LLM-approved death to X (Twitter) at `x.com/CelebDeathBot`.
 
-- Format matches Telegram, but the Wikipedia link is appended at the end (since X posts cannot embed clickable HTML links):
+- Automatic posting is disabled unless `POST_TO_X=true`.
+- Automatic X posts omit Wikipedia links unless `X_POST_INCLUDE_WIKIPEDIA_LINK=true`.
+- The `/llm-debug` dashboard includes a manual **Post to X** button for approved rows. It opens X's browser composer with the Wikipedia link included.
+- When link inclusion is enabled, format matches Telegram, but the Wikipedia link is appended at the end (since X posts cannot embed clickable HTML links):
   - Example: `🚨💀Jane Doe (88) : American actor and philanthropist - cancer 💀🚨\nhttps://en.wikipedia.org/wiki/Jane_Doe`
 - Length is constrained to 280 characters with t.co URL weighting (23 chars). The body text is truncated with an ellipsis if necessary.
 

--- a/src/routes/llm-debug.ts
+++ b/src/routes/llm-debug.ts
@@ -1,7 +1,7 @@
 import type { Env } from '../types.ts';
 import { buildSafeUrl, toStr } from '../utils/strings.ts';
 import { buildTelegramMessage, notifyTelegram } from '../services/telegram.ts';
-import { buildXStatus, postToXIfConfigured } from '../services/x.ts';
+import { buildXStatus, postToXIfConfigured, shouldIncludeWikipediaLinkInXPost } from '../services/x.ts';
 import { runJob, runJobForIds } from '../services/job.ts';
 import { getDefaultLlmModel, getDefaultLlmProvider } from '../services/llm.ts';
 import { requireAuth } from '../auth.ts';
@@ -183,14 +183,17 @@ async function handlePost(request: Request, env: Env, ctx: ExecutionContext): Pr
 				link_type: row.link_type,
 			});
 			await notifyTelegram(env, msg);
-			const xText = buildXStatus({
-				name: row.name,
-				age,
-				description,
-				cause,
-				wiki_path: row.wiki_path,
-				link_type: row.link_type,
-			});
+			const xText = buildXStatus(
+				{
+					name: row.name,
+					age,
+					description,
+					cause,
+					wiki_path: row.wiki_path,
+					link_type: row.link_type,
+				},
+				{ includeWikipediaLink: shouldIncludeWikipediaLinkInXPost(env) }
+			);
 			await postToXIfConfigured(env, xText);
 		}
 
@@ -545,8 +548,8 @@ function renderPage(
 		.edit-grid label { font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.04em; color: var(--muted); }
 		.edit-grid input, .edit-grid textarea, .edit-grid select { width: 100%; border: 1px solid var(--border); border-radius: 8px; padding: 8px 10px; font: inherit; background: #fff; }
 		.edit-grid textarea { resize: vertical; min-height: 72px; }
-		button.secondary { padding: 8px 14px; border-radius: 10px; border: 1px solid var(--border); background: #fff; font-weight: 600; cursor: pointer; color: var(--text); }
-		button.secondary:hover { border-color: var(--accent); color: var(--accent); }
+		button.secondary, a.secondary { display: inline-flex; align-items: center; justify-content: center; padding: 8px 14px; border-radius: 10px; border: 1px solid var(--border); background: #fff; font-weight: 600; cursor: pointer; color: var(--text); font: inherit; line-height: 1.2; }
+		button.secondary:hover, a.secondary:hover { border-color: var(--accent); color: var(--accent); text-decoration: none; }
 		button.danger { padding: 10px 16px; border-radius: 12px; border: 1px solid rgba(214, 69, 93, 0.55); background: rgba(214, 69, 93, 0.12); font-weight: 700; cursor: pointer; color: var(--danger); }
 		button.danger:hover { border-color: var(--danger); background: rgba(214, 69, 93, 0.18); }
 		.llm-form { display: flex; align-items: center; gap: 10px; }
@@ -769,6 +772,22 @@ function renderRow(
 	const ageValue = row.age == null ? '' : String(row.age);
 	const descriptionValue = row.description ?? '';
 	const causeValue = row.cause ?? '';
+	const manualXUrl =
+		llmLabel === 'yes'
+			? buildTweetIntentUrl(
+					buildXStatus(
+						{
+							name: row.name,
+							age: row.age,
+							description: row.description,
+							cause: row.cause,
+							wiki_path: row.wiki_path,
+							link_type: row.link_type,
+						},
+						{ includeWikipediaLink: true }
+					)
+				)
+			: '';
 
 	return `<div class="result-card">
 	<div class="result-main">
@@ -818,9 +837,16 @@ function renderRow(
 				<button class="secondary" type="submit">Refresh via LLM</button>
 				<span class="helper">Provider: ${escapeHtml(llmMeta.providerLabel)} • Model: ${escapeHtml(llmMeta.model)}</span>
 			</form>
+			${manualXUrl ? `<a class="secondary" href="${escapeHtml(manualXUrl)}" target="_blank" rel="noopener noreferrer">Post to X</a>` : ''}
 		</div>
 	</div>
 </div>`;
+}
+
+function buildTweetIntentUrl(text: string): string {
+	const url = new URL('https://twitter.com/intent/tweet');
+	url.searchParams.set('text', text);
+	return url.toString();
 }
 
 function renderPagerLink(label: string, href: string, enabled: boolean): string {

--- a/src/services/llm-output.ts
+++ b/src/services/llm-output.ts
@@ -3,7 +3,7 @@ import { extractAndParseJSON, normalizeToArray, isObject } from '../utils/json.t
 import { toStr } from '../utils/strings.ts';
 import { getLinkTypeMap, markDeathsAsError, markDeathsAsNo, updateDeathLLM } from './db.ts';
 import { buildTelegramMessage, notifyTelegram } from './telegram.ts';
-import { buildXStatus, postToXIfConfigured } from './x.ts';
+import { buildXStatus, postToXIfConfigured, shouldIncludeWikipediaLinkInXPost } from './x.ts';
 
 type SelectedRejected = {
 	selected?: Array<Record<string, unknown>>;
@@ -193,7 +193,7 @@ export async function applyLlmOutput(env: Env, outputText: string, candidatePath
 
 			const msg = buildTelegramMessage({ name, age, description: desc, cause, wiki_path, link_type });
 			await notifyTelegram(env, msg);
-			const xText = buildXStatus({ name, age, description: desc, cause, wiki_path, link_type });
+			const xText = buildXStatus({ name, age, description: desc, cause, wiki_path, link_type }, { includeWikipediaLink: shouldIncludeWikipediaLinkInXPost(env) });
 			await postToXIfConfigured(env, xText);
 			notified++;
 

--- a/src/services/x.ts
+++ b/src/services/x.ts
@@ -210,16 +210,29 @@ export async function xOauthStatus(env: Env): Promise<Response> {
 
 // ---------- Posting ----------
 
-// Build X post matching Telegram content, but with the Wikipedia link appended at the end.
+// Build X post matching Telegram content, optionally with the Wikipedia link appended at the end.
 type PostInput = { name?: string | null; age?: string | number | null; description?: string | null; cause?: string | null; wiki_path?: string | null; link_type?: 'active' | 'edit' | null };
 
-export function buildXStatus({ name, age, description, cause, wiki_path, link_type }: PostInput): string {
+function isEnabledFlag(value?: string): boolean {
+  const normalized = (value || '').trim().toLowerCase();
+  return normalized === 'true' || normalized === '1' || normalized === 'yes' || normalized === 'on';
+}
+
+export function shouldPostToX(env: Env): boolean {
+  return isEnabledFlag(env.POST_TO_X);
+}
+
+export function shouldIncludeWikipediaLinkInXPost(env: Env): boolean {
+  return isEnabledFlag(env.X_POST_INCLUDE_WIKIPEDIA_LINK);
+}
+
+export function buildXStatus({ name, age, description, cause, wiki_path, link_type }: PostInput, opts?: { includeWikipediaLink?: boolean }): string {
   const safeName = (name ?? '').toString().trim();
   const safeAge = age == null || age === '' ? '' : ` (${String(age).trim()})`;
   const safeDesc = (description ?? '').toString().trim();
   const causeRaw = (cause ?? '').toString().trim();
   const hasCause = causeRaw && causeRaw.toLowerCase() !== 'unknown';
-  const url = link_type === 'active' && wiki_path ? buildSafeUrl(wiki_path || '') : '';
+  const url = opts?.includeWikipediaLink && link_type === 'active' && wiki_path ? buildSafeUrl(wiki_path || '') : '';
 
   const bodyParts: string[] = [];
   bodyParts.push('🚨💀 ');
@@ -247,6 +260,9 @@ function truncateToCodepoints(s: string, max: number): string {
 }
 
 export async function postToXIfConfigured(env: Env, text: string): Promise<void> {
+  if (!shouldPostToX(env)) {
+    return;
+  }
   // Ensure we have an access token (refresh if needed)
   const token = await refreshIfNeeded(env);
   if (!token) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,9 @@ export interface Env {
   X_CLIENT_SECRET?: string;
   // Symmetric key (base64) to encrypt tokens at rest in D1
   X_ENC_KEY?: string;
+  // Optional: automatic X posting flags. Missing or non-true values are treated as false.
+  POST_TO_X?: string;
+  X_POST_INCLUDE_WIKIPEDIA_LINK?: string;
   // Optional: configure rate limits for /run as "60:3,3600:20"
   RUN_RATE_LIMITS?: string;
   // Optional: LLM provider override ("openai" or "replicate")

--- a/tests/x.test.js
+++ b/tests/x.test.js
@@ -1,0 +1,47 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildXStatus, postToXIfConfigured, shouldIncludeWikipediaLinkInXPost, shouldPostToX } from '../src/services/x.ts';
+
+const postInput = {
+  name: 'Jane Doe',
+  age: 88,
+  description: 'American actor',
+  cause: 'unknown',
+  wiki_path: 'Jane_Doe',
+  link_type: 'active',
+};
+
+test('X posting flags default to false', () => {
+  assert.equal(shouldPostToX({}), false);
+  assert.equal(shouldIncludeWikipediaLinkInXPost({}), false);
+});
+
+test('X posting flags accept explicit true values', () => {
+  assert.equal(shouldPostToX({ POST_TO_X: 'true' }), true);
+  assert.equal(shouldPostToX({ POST_TO_X: '1' }), true);
+  assert.equal(shouldIncludeWikipediaLinkInXPost({ X_POST_INCLUDE_WIKIPEDIA_LINK: 'yes' }), true);
+  assert.equal(shouldIncludeWikipediaLinkInXPost({ X_POST_INCLUDE_WIKIPEDIA_LINK: 'on' }), true);
+});
+
+test('buildXStatus omits Wikipedia link unless requested', () => {
+  const text = buildXStatus(postInput);
+  assert.ok(!text.includes('https://en.wikipedia.org/wiki/Jane_Doe'));
+});
+
+test('buildXStatus includes Wikipedia link when requested', () => {
+  const text = buildXStatus(postInput, { includeWikipediaLink: true });
+  assert.ok(text.includes('https://en.wikipedia.org/wiki/Jane_Doe'));
+});
+
+test('postToXIfConfigured returns before network work when disabled', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => {
+    throw new Error('fetch should not be called');
+  };
+  try {
+    await postToXIfConfigured({}, 'test');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -39,6 +39,10 @@
     "BASE_URL": "https://celebrity-death-bot.bruce-hart.workers.dev",
     "X_PROFILE_URL": "https://x.com/CelebDeathBot",
     "TELEGRAM_BOT_URL": "https://t.me/CelebrityDeathBot",
+    // Automatic X posting is disabled unless this is explicitly true.
+    "POST_TO_X": "false",
+    // Automatic X posts omit Wikipedia links unless this is explicitly true.
+    "X_POST_INCLUDE_WIKIPEDIA_LINK": "false",
     // Include previous month when current NY day is <= LOOKBACK_DAYS
     "LOOKBACK_DAYS": "15",
     // Comma/space/semicolon delimited list of permitted Google account emails


### PR DESCRIPTION
## Summary
- disable automatic X posting unless POST_TO_X is explicitly enabled
- omit Wikipedia links from automatic X posts unless X_POST_INCLUDE_WIKIPEDIA_LINK is enabled
- add a /llm-debug Post to X Web Intent button for approved rows, including the Wikipedia link
- add tests for X posting flags and link behavior

## Verification
- npm test
- npx wrangler deploy --dry-run --outdir /tmp/celebrity-death-bot-dry-run