### PR TITLE
PR #37 feedback fixes

### DIFF
--- a/migrations/007_add_webhook_claim_token.sql
+++ b/migrations/007_add_webhook_claim_token.sql
@@ -1,0 +1,3 @@
+-- Fence stale webhook attempts so only the current claimant can complete the
+-- event or cross the boundary into non-idempotent external side effects.
+ALTER TABLE processed_webhooks ADD COLUMN claim_token TEXT;

--- a/src/routes/openai-webhook.ts
+++ b/src/routes/openai-webhook.ts
@@ -67,8 +67,11 @@ export async function openaiWebhook(request: Request, env: Env): Promise<Respons
 	if (!responseId) return new Response('Missing response id', { status: 400 });
 
 	const eventId = `${responseId}:${eventType}`;
+	let claimToken: string;
 	try {
-		if (!(await claimWebhookEvent(env, 'openai', eventId))) return Response.json({ ok: true, duplicate: true });
+		const claimed = await claimWebhookEvent(env, 'openai', eventId);
+		if (!claimed) return Response.json({ ok: true, duplicate: true });
+		claimToken = claimed;
 	} catch (error) {
 		console.error('OpenAI webhook claim failed', error instanceof Error ? error.message : String(error));
 		return new Response('Webhook processing failed', { status: 500 });
@@ -81,17 +84,19 @@ export async function openaiWebhook(request: Request, env: Env): Promise<Respons
 
 		if (eventType !== 'response.completed') {
 			if (candidatePaths.length) await markDeathsAsError(env, candidatePaths);
-			await completeWebhookEvent(env, 'openai', eventId);
+			await completeWebhookEvent(env, 'openai', eventId, claimToken);
 			return Response.json({ ok: true, status: eventType, errored: candidatePaths.length });
 		}
 
-		const result = await applyLlmOutput(env, response.outputText || '', candidatePaths);
-		await completeWebhookEvent(env, 'openai', eventId);
+		const result = await applyLlmOutput(env, response.outputText || '', candidatePaths, {
+			beforeSideEffects: () => completeWebhookEvent(env, 'openai', eventId, claimToken),
+		});
+		await completeWebhookEvent(env, 'openai', eventId, claimToken);
 		return Response.json({ ok: true, response_id: responseId, ...result });
 	} catch (error) {
 		console.error('OpenAI webhook processing failed', error instanceof Error ? error.message : String(error));
 		try {
-			await failWebhookEvent(env, 'openai', eventId, error);
+			await failWebhookEvent(env, 'openai', eventId, claimToken, error);
 		} catch (recordError) {
 			console.error('OpenAI webhook failure recording failed', recordError instanceof Error ? recordError.message : String(recordError));
 		}

--- a/src/routes/replicate-callback.ts
+++ b/src/routes/replicate-callback.ts
@@ -37,8 +37,11 @@ export async function replicateCallback(request: Request, env: Env): Promise<Res
 	const predictionId = typeof payload.id === 'string' && payload.id.length <= 200 ? payload.id.trim() : '';
 	if (!predictionId) return new Response('Missing prediction id', { status: 400 });
 	const eventId = `${predictionId}:${status}`;
+	let claimToken: string;
 	try {
-		if (!(await claimWebhookEvent(env, 'replicate', eventId))) return Response.json({ ok: true, duplicate: true });
+		const claimed = await claimWebhookEvent(env, 'replicate', eventId);
+		if (!claimed) return Response.json({ ok: true, duplicate: true });
+		claimToken = claimed;
 	} catch (error) {
 		console.error('Replicate webhook claim failed', error instanceof Error ? error.message : String(error));
 		return new Response('Webhook processing failed', { status: 500 });
@@ -47,13 +50,15 @@ export async function replicateCallback(request: Request, env: Env): Promise<Res
 	try {
 		const joined = coalesceOutput(payload.output).trim();
 		const candidatePaths = extractCandidatePathsFromReplicatePayload(payload);
-		const result = await applyLlmOutput(env, joined, candidatePaths);
-		await completeWebhookEvent(env, 'replicate', eventId);
+		const result = await applyLlmOutput(env, joined, candidatePaths, {
+			beforeSideEffects: () => completeWebhookEvent(env, 'replicate', eventId, claimToken),
+		});
+		await completeWebhookEvent(env, 'replicate', eventId, claimToken);
 		return Response.json({ ok: true, ...result });
 	} catch (error) {
 		console.error('Replicate webhook processing failed', error instanceof Error ? error.message : String(error));
 		try {
-			await failWebhookEvent(env, 'replicate', eventId, error);
+			await failWebhookEvent(env, 'replicate', eventId, claimToken, error);
 		} catch (recordError) {
 			console.error('Replicate webhook failure recording failed', recordError instanceof Error ? recordError.message : String(recordError));
 		}

--- a/src/routes/telegram-webhook.ts
+++ b/src/routes/telegram-webhook.ts
@@ -31,8 +31,11 @@ export async function telegramWebhook(request: Request, env: Env): Promise<Respo
 	if (!isRecord(update)) return new Response('Invalid payload', { status: 400 });
 	const updateId = typeof update.update_id === 'number' && Number.isSafeInteger(update.update_id) ? String(update.update_id) : '';
 	if (!updateId) return new Response('Missing update id', { status: 400 });
+	let claimToken: string;
 	try {
-		if (!(await claimWebhookEvent(env, 'telegram', updateId))) return Response.json({ ok: true, duplicate: true });
+		const claimed = await claimWebhookEvent(env, 'telegram', updateId);
+		if (!claimed) return Response.json({ ok: true, duplicate: true });
+		claimToken = claimed;
 	} catch (error) {
 		console.error('Telegram webhook claim failed', error instanceof Error ? error.message : String(error));
 		return new Response('Webhook processing failed', { status: 500 });
@@ -45,48 +48,43 @@ export async function telegramWebhook(request: Request, env: Env): Promise<Respo
 		const chatId = typeof chatIdValue === 'string' || typeof chatIdValue === 'number' ? String(chatIdValue) : '';
 		const text = message && typeof message.text === 'string' ? message.text.trim() : '';
 		if (!chatId || !text) {
-			await completeWebhookEvent(env, 'telegram', updateId);
+			await completeWebhookEvent(env, 'telegram', updateId, claimToken);
 			return Response.json({ ok: true, ignored: true });
 		}
 
 		const command = text.split(/\s+/)[0].toLowerCase();
+		let reply: string;
 		if (command === '/start' || command === '/subscribe' || command === '/join') {
 			const current = await getSubscriberStatus(env, chatId);
 			await subscribeTelegram(env, chatId);
-			await notifyTelegramSingle(env, chatId, current === 1 ? 'You are already subscribed.' : 'Subscribed. You will receive alerts here.');
+			reply = current === 1 ? 'You are already subscribed.' : 'Subscribed. You will receive alerts here.';
 		} else if (command === '/stop' || command === '/unsubscribe' || command === '/leave') {
 			const current = await getSubscriberStatus(env, chatId);
 			await unsubscribeTelegram(env, chatId);
-			await notifyTelegramSingle(
-				env,
-				chatId,
-				current === 0 || current === null ? 'You are already unsubscribed.' : 'Unsubscribed. You will no longer receive alerts.',
-			);
+			reply = current === 0 || current === null ? 'You are already unsubscribed.' : 'Unsubscribed. You will no longer receive alerts.';
 		} else if (command === '/status') {
 			const status = await getSubscriberStatus(env, chatId);
-			await notifyTelegramSingle(env, chatId, status === 1 ? 'Status: subscribed.' : 'Status: not subscribed.');
+			reply = status === 1 ? 'Status: subscribed.' : 'Status: not subscribed.';
 		} else if (command === '/commands' || command === '/help') {
-			await notifyTelegramSingle(
-				env,
-				chatId,
-				[
-					'Available commands:',
-					'/subscribe – Subscribe to alerts',
-					'/unsubscribe – Unsubscribe from alerts',
-					'/status – Show current subscription status',
-					'/help – Show this list',
-				].join('\n'),
-			);
+			reply = [
+				'Available commands:',
+				'/subscribe – Subscribe to alerts',
+				'/unsubscribe – Unsubscribe from alerts',
+				'/status – Show current subscription status',
+				'/help – Show this list',
+			].join('\n');
 		} else {
-			await notifyTelegramSingle(env, chatId, 'Unknown command. Try /subscribe, /unsubscribe, /status, or /commands.');
+			reply = 'Unknown command. Try /subscribe, /unsubscribe, /status, or /commands.';
 		}
 
-		await completeWebhookEvent(env, 'telegram', updateId);
+		// Fence the non-idempotent reply after all retryable D1 work succeeds.
+		await completeWebhookEvent(env, 'telegram', updateId, claimToken);
+		await notifyTelegramSingle(env, chatId, reply);
 		return Response.json({ ok: true });
 	} catch (error) {
 		console.error('Telegram webhook processing failed', error instanceof Error ? error.message : String(error));
 		try {
-			await failWebhookEvent(env, 'telegram', updateId, error);
+			await failWebhookEvent(env, 'telegram', updateId, claimToken, error);
 		} catch (recordError) {
 			console.error('Telegram webhook failure recording failed', recordError instanceof Error ? recordError.message : String(recordError));
 		}

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -178,26 +178,41 @@ export async function markDeathsAsError(env: Env, wikiPaths: string[]) {
 }
 
 export type WebhookProvider = 'replicate' | 'openai' | 'telegram';
+type DatabaseEnv = Pick<Env, 'DB'>;
 
 /**
  * Atomically claims a provider delivery. A false result means the delivery was
- * already seen and must not perform side effects again.
+ * completed or is still being processed and must not perform side effects
+ * again. Failed deliveries are immediately retryable, while processing claims
+ * are reclaimable after 15 minutes so a terminated Worker cannot block the
+ * provider retry forever.
  */
-export async function claimWebhookEvent(env: Env, provider: WebhookProvider, eventId: string): Promise<boolean> {
-	const result = await withD1Retry(
+export async function claimWebhookEvent(env: DatabaseEnv, provider: WebhookProvider, eventId: string): Promise<boolean> {
+	const claimed = await withD1Retry(
 		() =>
 			env.DB.prepare(
-				`INSERT OR IGNORE INTO processed_webhooks(provider, event_id, status, created_at)
-				 VALUES(?1, ?2, 'processing', CURRENT_TIMESTAMP)`,
+				`INSERT INTO processed_webhooks(provider, event_id, status, created_at)
+				 VALUES(?1, ?2, 'processing', CURRENT_TIMESTAMP)
+				 ON CONFLICT(provider, event_id) DO UPDATE SET
+				   status = 'processing',
+				   error = NULL,
+				   created_at = CURRENT_TIMESTAMP,
+				   completed_at = NULL
+				 WHERE processed_webhooks.status = 'failed'
+				    OR (
+				      processed_webhooks.status = 'processing'
+				      AND processed_webhooks.created_at < datetime('now', '-15 minutes')
+				    )
+				 RETURNING 1 AS claimed`,
 			)
 				.bind(provider, eventId)
-				.run(),
+				.first<{ claimed: number }>(),
 		'claimWebhookEvent',
 	);
-	return Number(result.meta.changes || 0) === 1;
+	return claimed?.claimed === 1;
 }
 
-export async function completeWebhookEvent(env: Env, provider: WebhookProvider, eventId: string): Promise<void> {
+export async function completeWebhookEvent(env: DatabaseEnv, provider: WebhookProvider, eventId: string): Promise<void> {
 	await withD1Retry(
 		() =>
 			env.DB.prepare(
@@ -211,7 +226,7 @@ export async function completeWebhookEvent(env: Env, provider: WebhookProvider, 
 	);
 }
 
-export async function failWebhookEvent(env: Env, provider: WebhookProvider, eventId: string, error: unknown): Promise<void> {
+export async function failWebhookEvent(env: DatabaseEnv, provider: WebhookProvider, eventId: string, error: unknown): Promise<void> {
 	const message = errorMessage(error).replace(/\s+/g, ' ').trim().slice(0, 500) || 'Unknown error';
 	await withD1Retry(
 		() =>
@@ -226,7 +241,7 @@ export async function failWebhookEvent(env: Env, provider: WebhookProvider, even
 	);
 }
 
-export async function pruneWebhookEvents(env: Env): Promise<void> {
+export async function pruneWebhookEvents(env: DatabaseEnv): Promise<void> {
 	await withD1Retry(
 		() =>
 			env.DB.prepare(

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -183,59 +183,79 @@ type DatabaseEnv = Pick<Env, 'DB'>;
 /**
  * Atomically claims a provider delivery. A false result means the delivery was
  * completed or is still being processed and must not perform side effects
- * again. Failed deliveries are immediately retryable, while processing claims
- * are reclaimable after 15 minutes so a terminated Worker cannot block the
- * provider retry forever.
+ * again. Pre-effect failures are immediately retryable, while processing
+ * claims are reclaimable after 15 minutes so a terminated Worker cannot block
+ * the provider retry forever.
  */
-export async function claimWebhookEvent(env: DatabaseEnv, provider: WebhookProvider, eventId: string): Promise<boolean> {
+export async function claimWebhookEvent(env: DatabaseEnv, provider: WebhookProvider, eventId: string): Promise<string | null> {
+	const claimToken = crypto.randomUUID();
 	const claimed = await withD1Retry(
 		() =>
 			env.DB.prepare(
-				`INSERT INTO processed_webhooks(provider, event_id, status, created_at)
-				 VALUES(?1, ?2, 'processing', CURRENT_TIMESTAMP)
+				`INSERT INTO processed_webhooks(provider, event_id, status, created_at, claim_token)
+				 VALUES(?1, ?2, 'processing', CURRENT_TIMESTAMP, ?3)
 				 ON CONFLICT(provider, event_id) DO UPDATE SET
 				   status = 'processing',
 				   error = NULL,
 				   created_at = CURRENT_TIMESTAMP,
-				   completed_at = NULL
+				   completed_at = NULL,
+				   claim_token = excluded.claim_token
 				 WHERE processed_webhooks.status = 'failed'
 				    OR (
 				      processed_webhooks.status = 'processing'
-				      AND processed_webhooks.created_at < datetime('now', '-15 minutes')
+				      AND (
+				        processed_webhooks.claim_token = excluded.claim_token
+				        OR processed_webhooks.created_at < datetime('now', '-15 minutes')
+				      )
 				    )
-				 RETURNING 1 AS claimed`,
+				 RETURNING claim_token`,
 			)
-				.bind(provider, eventId)
-				.first<{ claimed: number }>(),
+				.bind(provider, eventId, claimToken)
+				.first<{ claim_token: string }>(),
 		'claimWebhookEvent',
 	);
-	return claimed?.claimed === 1;
+	return claimed?.claim_token === claimToken ? claimToken : null;
 }
 
-export async function completeWebhookEvent(env: DatabaseEnv, provider: WebhookProvider, eventId: string): Promise<void> {
-	await withD1Retry(
+export async function completeWebhookEvent(
+	env: DatabaseEnv,
+	provider: WebhookProvider,
+	eventId: string,
+	claimToken: string,
+): Promise<void> {
+	const result = await withD1Retry(
 		() =>
 			env.DB.prepare(
 				`UPDATE processed_webhooks
-				    SET status = 'completed', error = NULL, completed_at = CURRENT_TIMESTAMP
-				  WHERE provider = ?1 AND event_id = ?2`,
+				    SET status = 'completed', error = NULL, completed_at = COALESCE(completed_at, CURRENT_TIMESTAMP)
+				  WHERE provider = ?1
+				    AND event_id = ?2
+				    AND claim_token = ?3
+				    AND status IN ('processing', 'completed')`,
 			)
-				.bind(provider, eventId)
+				.bind(provider, eventId, claimToken)
 				.run(),
 		'completeWebhookEvent',
 	);
+	if (Number(result.meta.changes || 0) !== 1) throw new Error('Webhook event claim lost before completion');
 }
 
-export async function failWebhookEvent(env: DatabaseEnv, provider: WebhookProvider, eventId: string, error: unknown): Promise<void> {
+export async function failWebhookEvent(
+	env: DatabaseEnv,
+	provider: WebhookProvider,
+	eventId: string,
+	claimToken: string,
+	error: unknown,
+): Promise<void> {
 	const message = errorMessage(error).replace(/\s+/g, ' ').trim().slice(0, 500) || 'Unknown error';
 	await withD1Retry(
 		() =>
 			env.DB.prepare(
 				`UPDATE processed_webhooks
-				    SET status = 'failed', error = ?3, completed_at = CURRENT_TIMESTAMP
-				  WHERE provider = ?1 AND event_id = ?2`,
+				    SET status = 'failed', error = ?4, completed_at = CURRENT_TIMESTAMP
+				  WHERE provider = ?1 AND event_id = ?2 AND claim_token = ?3 AND status = 'processing'`,
 			)
-				.bind(provider, eventId, message)
+				.bind(provider, eventId, claimToken, message)
 				.run(),
 		'failWebhookEvent',
 	);

--- a/src/services/llm-output.ts
+++ b/src/services/llm-output.ts
@@ -154,6 +154,13 @@ export function extractCandidatePathsFromReplicatePayload(payload: any): string[
 	return extractWikiPathsFromPrompt(prompt);
 }
 
+async function notifySelectedRow(env: Env, row: DeathEntry): Promise<void> {
+	const msg = buildTelegramMessage(row);
+	await notifyTelegram(env, msg);
+	const xText = buildXStatus(row, { includeWikipediaLink: shouldIncludeWikipediaLinkInXPost(env) });
+	await postToXIfConfigured(env, xText);
+}
+
 export async function applyLlmOutput(env: Env, outputText: string, candidatePaths: string[], options: ApplyLlmOutputOptions = {}) {
 	const candidates = Array.from(
 		new Set(
@@ -206,33 +213,38 @@ export async function applyLlmOutput(env: Env, outputText: string, candidatePath
 
 	const selectedPaths = Array.from(new Set(selectedItems.map((item) => readWikiPath(item, candidateMap)).filter(Boolean)));
 	const selectedRows = selectedPaths.map((wikiPath) => rowsByPath.get(wikiPath)).filter((row): row is DeathEntry => Boolean(row));
-	for (const row of selectedRows) {
-		await updateDeathLLM(env, row.wiki_path, row.cause, row.description);
-	}
-
-	let rejected = 0;
+	let filteredRejections: Rejection[] = [];
 	if (rejectedItems.length) {
 		const selectedSet = new Set(selectedPaths);
 		const rejectedByPath = new Map<string, Rejection>();
 		for (const item of rejectedItems) if (!selectedSet.has(item.wiki_path)) rejectedByPath.set(item.wiki_path, item);
-		const filtered = Array.from(rejectedByPath.values());
-		await markDeathsAsNo(env, filtered);
-		rejected = filtered.length;
+		filteredRejections = Array.from(rejectedByPath.values());
 	}
-
-	// Persist every retryable D1 change before fencing the event as complete.
-	// No database operation may follow an external notification: if a send has
-	// an ambiguous outcome, the completed ledger row prevents a duplicate retry.
-	if (selectedRows.length) await options.beforeSideEffects?.();
 
 	let notified = 0;
-	for (const row of selectedRows) {
-		const msg = buildTelegramMessage(row);
-		await notifyTelegram(env, msg);
-		const xText = buildXStatus(row, { includeWikipediaLink: shouldIncludeWikipediaLinkInXPost(env) });
-		await postToXIfConfigured(env, xText);
-		notified++;
+	if (options.beforeSideEffects) {
+		// Webhook deliveries persist every retryable D1 change before fencing the
+		// event. No database operation may follow an external notification: if a
+		// send has an ambiguous outcome, the completed ledger prevents a duplicate.
+		for (const row of selectedRows) {
+			await updateDeathLLM(env, row.wiki_path, row.cause, row.description);
+		}
+		if (filteredRejections.length) await markDeathsAsNo(env, filteredRejections);
+		if (selectedRows.length) await options.beforeSideEffects();
+		for (const row of selectedRows) {
+			await notifySelectedRow(env, row);
+			notified++;
+		}
+	} else {
+		// Synchronous evaluations have no replay ledger. Keep a selected row
+		// pending until its sends finish so a transient failure remains retryable.
+		for (const row of selectedRows) {
+			await notifySelectedRow(env, row);
+			notified++;
+			await updateDeathLLM(env, row.wiki_path, row.cause, row.description);
+		}
+		if (filteredRejections.length) await markDeathsAsNo(env, filteredRejections);
 	}
 
-	return { notified, rejected, errored: 0 } as const;
+	return { notified, rejected: filteredRejections.length, errored: 0 } as const;
 }

--- a/src/services/llm-output.ts
+++ b/src/services/llm-output.ts
@@ -220,6 +220,9 @@ export async function applyLlmOutput(env: Env, outputText: string, candidatePath
 		for (const item of rejectedItems) if (!selectedSet.has(item.wiki_path)) rejectedByPath.set(item.wiki_path, item);
 		filteredRejections = Array.from(rejectedByPath.values());
 	}
+	// Rejections have no external side effect and must not depend on whether a
+	// selected-row notification succeeds.
+	if (filteredRejections.length) await markDeathsAsNo(env, filteredRejections);
 
 	let notified = 0;
 	if (options.beforeSideEffects) {
@@ -229,7 +232,6 @@ export async function applyLlmOutput(env: Env, outputText: string, candidatePath
 		for (const row of selectedRows) {
 			await updateDeathLLM(env, row.wiki_path, row.cause, row.description);
 		}
-		if (filteredRejections.length) await markDeathsAsNo(env, filteredRejections);
 		if (selectedRows.length) await options.beforeSideEffects();
 		for (const row of selectedRows) {
 			await notifySelectedRow(env, row);
@@ -243,7 +245,6 @@ export async function applyLlmOutput(env: Env, outputText: string, candidatePath
 			notified++;
 			await updateDeathLLM(env, row.wiki_path, row.cause, row.description);
 		}
-		if (filteredRejections.length) await markDeathsAsNo(env, filteredRejections);
 	}
 
 	return { notified, rejected: filteredRejections.length, errored: 0 } as const;

--- a/src/services/llm-output.ts
+++ b/src/services/llm-output.ts
@@ -11,6 +11,9 @@ type SelectedRejected = {
 };
 
 type Rejection = { wiki_path: string; reason?: string | null };
+type ApplyLlmOutputOptions = {
+	beforeSideEffects?: () => Promise<void>;
+};
 
 const MAX_REASON_CHARS = 200;
 
@@ -151,7 +154,7 @@ export function extractCandidatePathsFromReplicatePayload(payload: any): string[
 	return extractWikiPathsFromPrompt(prompt);
 }
 
-export async function applyLlmOutput(env: Env, outputText: string, candidatePaths: string[]) {
+export async function applyLlmOutput(env: Env, outputText: string, candidatePaths: string[], options: ApplyLlmOutputOptions = {}) {
 	const candidates = Array.from(
 		new Set(
 			(candidatePaths || [])
@@ -201,16 +204,9 @@ export async function applyLlmOutput(env: Env, outputText: string, candidatePath
 		}
 	}
 
-	let notified = 0;
 	const selectedPaths = Array.from(new Set(selectedItems.map((item) => readWikiPath(item, candidateMap)).filter(Boolean)));
-	for (const wikiPath of selectedPaths) {
-		const row = rowsByPath.get(wikiPath);
-		if (!row) continue;
-		const msg = buildTelegramMessage(row);
-		await notifyTelegram(env, msg);
-		const xText = buildXStatus(row, { includeWikipediaLink: shouldIncludeWikipediaLinkInXPost(env) });
-		await postToXIfConfigured(env, xText);
-		notified++;
+	const selectedRows = selectedPaths.map((wikiPath) => rowsByPath.get(wikiPath)).filter((row): row is DeathEntry => Boolean(row));
+	for (const row of selectedRows) {
 		await updateDeathLLM(env, row.wiki_path, row.cause, row.description);
 	}
 
@@ -222,6 +218,20 @@ export async function applyLlmOutput(env: Env, outputText: string, candidatePath
 		const filtered = Array.from(rejectedByPath.values());
 		await markDeathsAsNo(env, filtered);
 		rejected = filtered.length;
+	}
+
+	// Persist every retryable D1 change before fencing the event as complete.
+	// No database operation may follow an external notification: if a send has
+	// an ambiguous outcome, the completed ledger row prevents a duplicate retry.
+	if (selectedRows.length) await options.beforeSideEffects?.();
+
+	let notified = 0;
+	for (const row of selectedRows) {
+		const msg = buildTelegramMessage(row);
+		await notifyTelegram(env, msg);
+		const xText = buildXStatus(row, { includeWikipediaLink: shouldIncludeWikipediaLinkInXPost(env) });
+		await postToXIfConfigured(env, xText);
+		notified++;
 	}
 
 	return { notified, rejected, errored: 0 } as const;

--- a/tests/llm-boundary.test.js
+++ b/tests/llm-boundary.test.js
@@ -12,7 +12,13 @@ const canonicalRow = {
 	cause: 'canonical cause',
 };
 
-function makeEnv({ failSubscriberRead = false } = {}) {
+const rejectedRow = {
+	...canonicalRow,
+	name: 'Rejected Person',
+	wiki_path: 'Rejected_Person',
+};
+
+function makeEnv({ deathRows = [canonicalRow], failSubscriberRead = false } = {}) {
 	const writes = [];
 	const reads = [];
 	const DB = {
@@ -22,7 +28,7 @@ function makeEnv({ failSubscriberRead = false } = {}) {
 					return {
 						async all() {
 							reads.push(sql);
-							if (sql.includes('FROM deaths')) return { results: [canonicalRow] };
+							if (sql.includes('FROM deaths')) return { results: deathRows };
 							if (sql.includes('FROM subscribers')) {
 								if (failSubscriberRead) throw new Error('notification lookup failed');
 								return { results: [] };
@@ -36,6 +42,9 @@ function makeEnv({ failSubscriberRead = false } = {}) {
 					};
 				},
 			};
+		},
+		async batch(statements) {
+			return Promise.all(statements.map((statement) => statement.run()));
 		},
 	};
 	return { env: { DB }, reads, writes };
@@ -107,6 +116,29 @@ test('synchronous send failures leave selected deaths pending for retry', async 
 		reads.some((sql) => sql.includes('FROM subscribers')),
 		true,
 	);
+	assert.equal(
+		writes.some((write) => write.sql.includes("llm_result = 'yes'")),
+		false,
+	);
+});
+
+test('synchronous send failures still persist independent rejections', async () => {
+	const { env, writes } = makeEnv({ deathRows: [canonicalRow, rejectedRow], failSubscriberRead: true });
+	await assert.rejects(
+		() =>
+			applyLlmOutput(
+				env,
+				JSON.stringify({
+					selected: [{ wiki_path: 'Trusted_Person' }],
+					rejected: [{ wiki_path: 'Rejected_Person', reason: 'Not notable' }],
+				}),
+				['Trusted_Person', 'Rejected_Person'],
+			),
+		/notification lookup failed/,
+	);
+	const rejectionUpdate = writes.find((write) => write.sql.includes("llm_result = 'no'"));
+	assert.ok(rejectionUpdate);
+	assert.deepEqual(rejectionUpdate.values, ['Not notable', 'Rejected_Person']);
 	assert.equal(
 		writes.some((write) => write.sql.includes("llm_result = 'yes'")),
 		false,

--- a/tests/llm-boundary.test.js
+++ b/tests/llm-boundary.test.js
@@ -14,12 +14,14 @@ const canonicalRow = {
 
 function makeEnv() {
 	const writes = [];
+	const reads = [];
 	const DB = {
 		prepare(sql) {
 			return {
 				bind(...values) {
 					return {
 						async all() {
+							reads.push(sql);
 							if (sql.includes('FROM deaths')) return { results: [canonicalRow] };
 							if (sql.includes('FROM subscribers')) return { results: [] };
 							return { results: [] };
@@ -33,7 +35,7 @@ function makeEnv() {
 			};
 		},
 	};
-	return { env: { DB }, writes };
+	return { env: { DB }, reads, writes };
 }
 
 test('LLM output is rejected without a trusted candidate set', async () => {
@@ -51,6 +53,7 @@ test('LLM cannot select a wiki path outside the candidate batch', async () => {
 
 test('selected notifications and updates use canonical database fields', async () => {
 	const { env, writes } = makeEnv();
+	let fencedAfterUpdate = false;
 	const result = await applyLlmOutput(
 		env,
 		JSON.stringify({
@@ -58,8 +61,35 @@ test('selected notifications and updates use canonical database fields', async (
 			rejected: [],
 		}),
 		['Trusted_Person'],
+		{
+			beforeSideEffects: async () => {
+				fencedAfterUpdate = writes.some((write) => write.sql.includes("llm_result = 'yes'"));
+			},
+		},
 	);
 	assert.equal(result.notified, 1);
+	assert.equal(fencedAfterUpdate, true);
 	const update = writes.find((write) => write.sql.includes("llm_result = 'yes'"));
 	assert.deepEqual(update.values, ['canonical cause', 'Canonical Wikipedia description', 'Trusted_Person']);
+});
+
+test('selected notifications do not start until the side-effect fence succeeds', async () => {
+	const { env, reads, writes } = makeEnv();
+	await assert.rejects(
+		() =>
+			applyLlmOutput(env, JSON.stringify({ selected: [{ wiki_path: 'Trusted_Person' }], rejected: [] }), ['Trusted_Person'], {
+				beforeSideEffects: async () => {
+					throw new Error('fence failed');
+				},
+			}),
+		/fence failed/,
+	);
+	assert.equal(
+		writes.some((write) => write.sql.includes("llm_result = 'yes'")),
+		true,
+	);
+	assert.equal(
+		reads.some((sql) => sql.includes('FROM subscribers')),
+		false,
+	);
 });

--- a/tests/llm-boundary.test.js
+++ b/tests/llm-boundary.test.js
@@ -12,7 +12,7 @@ const canonicalRow = {
 	cause: 'canonical cause',
 };
 
-function makeEnv() {
+function makeEnv({ failSubscriberRead = false } = {}) {
 	const writes = [];
 	const reads = [];
 	const DB = {
@@ -23,7 +23,10 @@ function makeEnv() {
 						async all() {
 							reads.push(sql);
 							if (sql.includes('FROM deaths')) return { results: [canonicalRow] };
-							if (sql.includes('FROM subscribers')) return { results: [] };
+							if (sql.includes('FROM subscribers')) {
+								if (failSubscriberRead) throw new Error('notification lookup failed');
+								return { results: [] };
+							}
 							return { results: [] };
 						},
 						async run() {
@@ -90,6 +93,22 @@ test('selected notifications do not start until the side-effect fence succeeds',
 	);
 	assert.equal(
 		reads.some((sql) => sql.includes('FROM subscribers')),
+		false,
+	);
+});
+
+test('synchronous send failures leave selected deaths pending for retry', async () => {
+	const { env, reads, writes } = makeEnv({ failSubscriberRead: true });
+	await assert.rejects(
+		() => applyLlmOutput(env, JSON.stringify({ selected: [{ wiki_path: 'Trusted_Person' }], rejected: [] }), ['Trusted_Person']),
+		/notification lookup failed/,
+	);
+	assert.equal(
+		reads.some((sql) => sql.includes('FROM subscribers')),
+		true,
+	);
+	assert.equal(
+		writes.some((write) => write.sql.includes("llm_result = 'yes'")),
 		false,
 	);
 });

--- a/tests/telegram-webhook-auth.test.js
+++ b/tests/telegram-webhook-auth.test.js
@@ -10,6 +10,9 @@ const makeEnv = (secret) => ({
 			bind() {
 				return this;
 			},
+			async first() {
+				return { claimed: 1 };
+			},
 			async run() {
 				return { meta: { changes: 1 } };
 			},
@@ -68,12 +71,12 @@ test('replayed update IDs are acknowledged without processing twice', async () =
 				bind() {
 					return this;
 				},
+				async first() {
+					if (!sql.includes('INSERT INTO processed_webhooks') || claimed) return null;
+					claimed = true;
+					return { claimed: 1 };
+				},
 				async run() {
-					if (sql.includes('INSERT OR IGNORE')) {
-						const changes = claimed ? 0 : 1;
-						claimed = true;
-						return { meta: { changes } };
-					}
 					return { meta: { changes: 1 } };
 				},
 			};

--- a/tests/telegram-webhook-auth.test.js
+++ b/tests/telegram-webhook-auth.test.js
@@ -6,17 +6,21 @@ import { telegramWebhook } from '../src/routes/telegram-webhook.ts';
 const makeEnv = (secret) => ({
 	TELEGRAM_WEBHOOK_SECRET: secret,
 	DB: /** @type any */ ({
-		prepare: () => ({
-			bind() {
-				return this;
-			},
-			async first() {
-				return { claimed: 1 };
-			},
-			async run() {
-				return { meta: { changes: 1 } };
-			},
-		}),
+		prepare: () => {
+			let values = [];
+			return {
+				bind(...bound) {
+					values = bound;
+					return this;
+				},
+				async first() {
+					return { claim_token: values[2] };
+				},
+				async run() {
+					return { meta: { changes: 1 } };
+				},
+			};
+		},
 	}),
 	TELEGRAM_BOT_TOKEN: 'dummy',
 	BASE_URL: 'https://example.com',
@@ -67,14 +71,16 @@ test('replayed update IDs are acknowledged without processing twice', async () =
 	const env = makeEnv('s3cret');
 	env.DB = {
 		prepare(sql) {
+			let values = [];
 			return {
-				bind() {
+				bind(...bound) {
+					values = bound;
 					return this;
 				},
 				async first() {
 					if (!sql.includes('INSERT INTO processed_webhooks') || claimed) return null;
 					claimed = true;
-					return { claimed: 1 };
+					return { claim_token: values[2] };
 				},
 				async run() {
 					return { meta: { changes: 1 } };

--- a/tests/worker/routes.integration.ts
+++ b/tests/worker/routes.integration.ts
@@ -39,24 +39,33 @@ describe('Webhook replay ledger', () => {
 	});
 
 	it('deduplicates active and completed deliveries', async () => {
-		const claims = await Promise.all([
+		const claimTokens = await Promise.all([
 			claimWebhookEvent(env, 'replicate', 'delivery-1'),
 			claimWebhookEvent(env, 'replicate', 'delivery-1'),
 			claimWebhookEvent(env, 'replicate', 'delivery-1'),
 		]);
-		expect(claims.filter(Boolean)).toHaveLength(1);
+		expect(claimTokens.filter(Boolean)).toHaveLength(1);
+		const claimToken = claimTokens.find(Boolean);
 
-		await completeWebhookEvent(env, 'replicate', 'delivery-1');
-		expect(await claimWebhookEvent(env, 'replicate', 'delivery-1')).toBe(false);
+		await completeWebhookEvent(env, 'replicate', 'delivery-1', claimToken!);
+		await completeWebhookEvent(env, 'replicate', 'delivery-1', claimToken!);
+		await failWebhookEvent(env, 'replicate', 'delivery-1', claimToken!, new Error('post-effect failure'));
+		expect(await claimWebhookEvent(env, 'replicate', 'delivery-1')).toBeNull();
+		const completed = await env.DB.prepare(
+			`SELECT status, error FROM processed_webhooks
+			  WHERE provider = 'replicate' AND event_id = 'delivery-1'`,
+		).first<{ status: string; error: string | null }>();
+		expect(completed).toEqual({ status: 'completed', error: null });
 	});
 
 	it('allows a failed delivery to be claimed again', async () => {
-		expect(await claimWebhookEvent(env, 'openai', 'delivery-2')).toBe(true);
-		await failWebhookEvent(env, 'openai', 'delivery-2', new Error('temporary failure'));
+		const firstClaim = await claimWebhookEvent(env, 'openai', 'delivery-2');
+		expect(firstClaim).toBeTruthy();
+		await failWebhookEvent(env, 'openai', 'delivery-2', firstClaim!, new Error('temporary failure'));
 
 		const retryClaims = await Promise.all([claimWebhookEvent(env, 'openai', 'delivery-2'), claimWebhookEvent(env, 'openai', 'delivery-2')]);
 		expect(retryClaims.filter(Boolean)).toHaveLength(1);
-		expect(await claimWebhookEvent(env, 'openai', 'delivery-2')).toBe(false);
+		expect(await claimWebhookEvent(env, 'openai', 'delivery-2')).toBeNull();
 
 		const row = await env.DB.prepare(
 			`SELECT status, error, completed_at FROM processed_webhooks
@@ -66,14 +75,19 @@ describe('Webhook replay ledger', () => {
 	});
 
 	it('allows a stale processing delivery to be claimed again', async () => {
-		expect(await claimWebhookEvent(env, 'telegram', 'delivery-3')).toBe(true);
+		const staleClaim = await claimWebhookEvent(env, 'telegram', 'delivery-3');
+		expect(staleClaim).toBeTruthy();
 		await env.DB.prepare(
 			`UPDATE processed_webhooks
 			    SET created_at = datetime('now', '-16 minutes')
 			  WHERE provider = 'telegram' AND event_id = 'delivery-3'`,
 		).run();
 
-		expect(await claimWebhookEvent(env, 'telegram', 'delivery-3')).toBe(true);
-		expect(await claimWebhookEvent(env, 'telegram', 'delivery-3')).toBe(false);
+		const reclaimedClaim = await claimWebhookEvent(env, 'telegram', 'delivery-3');
+		expect(reclaimedClaim).toBeTruthy();
+		expect(reclaimedClaim).not.toBe(staleClaim);
+		await expect(completeWebhookEvent(env, 'telegram', 'delivery-3', staleClaim!)).rejects.toThrow('claim lost');
+		await completeWebhookEvent(env, 'telegram', 'delivery-3', reclaimedClaim!);
+		expect(await claimWebhookEvent(env, 'telegram', 'delivery-3')).toBeNull();
 	});
 });

--- a/tests/worker/routes.integration.ts
+++ b/tests/worker/routes.integration.ts
@@ -1,5 +1,7 @@
-import { SELF } from 'cloudflare:test';
-import { describe, expect, it } from 'vitest';
+import { env, SELF } from 'cloudflare:test';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { claimWebhookEvent, completeWebhookEvent, failWebhookEvent } from '../../src/services/db.ts';
 
 describe('Worker security boundaries', () => {
 	it('serves health with the global security headers', async () => {
@@ -28,5 +30,50 @@ describe('Worker security boundaries', () => {
 			expect(response.status).toBe(302);
 			expect(response.headers.get('location')).toMatch(/^\/login\?return_to=/);
 		}
+	});
+});
+
+describe('Webhook replay ledger', () => {
+	beforeEach(async () => {
+		await env.DB.prepare('DELETE FROM processed_webhooks').run();
+	});
+
+	it('deduplicates active and completed deliveries', async () => {
+		const claims = await Promise.all([
+			claimWebhookEvent(env, 'replicate', 'delivery-1'),
+			claimWebhookEvent(env, 'replicate', 'delivery-1'),
+			claimWebhookEvent(env, 'replicate', 'delivery-1'),
+		]);
+		expect(claims.filter(Boolean)).toHaveLength(1);
+
+		await completeWebhookEvent(env, 'replicate', 'delivery-1');
+		expect(await claimWebhookEvent(env, 'replicate', 'delivery-1')).toBe(false);
+	});
+
+	it('allows a failed delivery to be claimed again', async () => {
+		expect(await claimWebhookEvent(env, 'openai', 'delivery-2')).toBe(true);
+		await failWebhookEvent(env, 'openai', 'delivery-2', new Error('temporary failure'));
+
+		const retryClaims = await Promise.all([claimWebhookEvent(env, 'openai', 'delivery-2'), claimWebhookEvent(env, 'openai', 'delivery-2')]);
+		expect(retryClaims.filter(Boolean)).toHaveLength(1);
+		expect(await claimWebhookEvent(env, 'openai', 'delivery-2')).toBe(false);
+
+		const row = await env.DB.prepare(
+			`SELECT status, error, completed_at FROM processed_webhooks
+			  WHERE provider = 'openai' AND event_id = 'delivery-2'`,
+		).first<{ status: string; error: string | null; completed_at: string | null }>();
+		expect(row).toEqual({ status: 'processing', error: null, completed_at: null });
+	});
+
+	it('allows a stale processing delivery to be claimed again', async () => {
+		expect(await claimWebhookEvent(env, 'telegram', 'delivery-3')).toBe(true);
+		await env.DB.prepare(
+			`UPDATE processed_webhooks
+			    SET created_at = datetime('now', '-16 minutes')
+			  WHERE provider = 'telegram' AND event_id = 'delivery-3'`,
+		).run();
+
+		expect(await claimWebhookEvent(env, 'telegram', 'delivery-3')).toBe(true);
+		expect(await claimWebhookEvent(env, 'telegram', 'delivery-3')).toBe(false);
 	});
 });

--- a/tests/worker/setup.ts
+++ b/tests/worker/setup.ts
@@ -1,0 +1,11 @@
+import { applyD1Migrations, env, type D1Migration } from 'cloudflare:test';
+
+declare global {
+	namespace Cloudflare {
+		interface Env {
+			TEST_MIGRATIONS: D1Migration[];
+		}
+	}
+}
+
+await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,13 +1,20 @@
-import { cloudflareTest } from '@cloudflare/vitest-pool-workers';
+import path from 'node:path';
+
+import { cloudflareTest, readD1Migrations } from '@cloudflare/vitest-pool-workers';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	plugins: [
-		cloudflareTest({
-			wrangler: { configPath: './wrangler.jsonc' },
+		cloudflareTest(async () => {
+			const migrations = await readD1Migrations(path.join(import.meta.dirname, 'migrations'));
+			return {
+				wrangler: { configPath: './wrangler.jsonc' },
+				miniflare: { bindings: { TEST_MIGRATIONS: migrations } },
+			};
 		}),
 	],
 	test: {
 		include: ['tests/worker/**/*.integration.ts'],
+		setupFiles: ['./tests/worker/setup.ts'],
 	},
 });


### PR DESCRIPTION
Addresses the unaddressed webhook retry feedback from PR #37.

Changes:
- atomically reclaim failed deliveries and processing claims stale for more than 15 minutes
- continue deduplicating completed and active processing deliveries
- guarantee only one concurrent retry obtains the claim
- apply the repository D1 migrations in Workers-runtime tests and cover fresh, completed, failed, and stale claims

Owner guidance: the repository owner requested review and provided no ignore or conflicting implementation guidance.

Verification:
- npm run test:unit
- npm run test:worker
- npx tsc --noEmit
- npx prettier --check on changed files