### PR TITLE
PR #39 feedback fixes

### DIFF
--- a/src/services/llm-output.ts
+++ b/src/services/llm-output.ts
@@ -154,6 +154,13 @@ export function extractCandidatePathsFromReplicatePayload(payload: any): string[
 	return extractWikiPathsFromPrompt(prompt);
 }
 
+async function notifySelectedRow(env: Env, row: DeathEntry): Promise<void> {
+	const msg = buildTelegramMessage(row);
+	await notifyTelegram(env, msg);
+	const xText = buildXStatus(row, { includeWikipediaLink: shouldIncludeWikipediaLinkInXPost(env) });
+	await postToXIfConfigured(env, xText);
+}
+
 export async function applyLlmOutput(env: Env, outputText: string, candidatePaths: string[], options: ApplyLlmOutputOptions = {}) {
 	const candidates = Array.from(
 		new Set(
@@ -206,33 +213,38 @@ export async function applyLlmOutput(env: Env, outputText: string, candidatePath
 
 	const selectedPaths = Array.from(new Set(selectedItems.map((item) => readWikiPath(item, candidateMap)).filter(Boolean)));
 	const selectedRows = selectedPaths.map((wikiPath) => rowsByPath.get(wikiPath)).filter((row): row is DeathEntry => Boolean(row));
-	for (const row of selectedRows) {
-		await updateDeathLLM(env, row.wiki_path, row.cause, row.description);
-	}
-
-	let rejected = 0;
+	let filteredRejections: Rejection[] = [];
 	if (rejectedItems.length) {
 		const selectedSet = new Set(selectedPaths);
 		const rejectedByPath = new Map<string, Rejection>();
 		for (const item of rejectedItems) if (!selectedSet.has(item.wiki_path)) rejectedByPath.set(item.wiki_path, item);
-		const filtered = Array.from(rejectedByPath.values());
-		await markDeathsAsNo(env, filtered);
-		rejected = filtered.length;
+		filteredRejections = Array.from(rejectedByPath.values());
 	}
-
-	// Persist every retryable D1 change before fencing the event as complete.
-	// No database operation may follow an external notification: if a send has
-	// an ambiguous outcome, the completed ledger row prevents a duplicate retry.
-	if (selectedRows.length) await options.beforeSideEffects?.();
 
 	let notified = 0;
-	for (const row of selectedRows) {
-		const msg = buildTelegramMessage(row);
-		await notifyTelegram(env, msg);
-		const xText = buildXStatus(row, { includeWikipediaLink: shouldIncludeWikipediaLinkInXPost(env) });
-		await postToXIfConfigured(env, xText);
-		notified++;
+	if (options.beforeSideEffects) {
+		// Webhook deliveries persist every retryable D1 change before fencing the
+		// event. No database operation may follow an external notification: if a
+		// send has an ambiguous outcome, the completed ledger prevents a duplicate.
+		for (const row of selectedRows) {
+			await updateDeathLLM(env, row.wiki_path, row.cause, row.description);
+		}
+		if (filteredRejections.length) await markDeathsAsNo(env, filteredRejections);
+		if (selectedRows.length) await options.beforeSideEffects();
+		for (const row of selectedRows) {
+			await notifySelectedRow(env, row);
+			notified++;
+		}
+	} else {
+		// Synchronous evaluations have no replay ledger. Keep a selected row
+		// pending until its sends finish so a transient failure remains retryable.
+		for (const row of selectedRows) {
+			await notifySelectedRow(env, row);
+			notified++;
+			await updateDeathLLM(env, row.wiki_path, row.cause, row.description);
+		}
+		if (filteredRejections.length) await markDeathsAsNo(env, filteredRejections);
 	}
 
-	return { notified, rejected, errored: 0 } as const;
+	return { notified, rejected: filteredRejections.length, errored: 0 } as const;
 }

--- a/src/services/llm-output.ts
+++ b/src/services/llm-output.ts
@@ -220,6 +220,9 @@ export async function applyLlmOutput(env: Env, outputText: string, candidatePath
 		for (const item of rejectedItems) if (!selectedSet.has(item.wiki_path)) rejectedByPath.set(item.wiki_path, item);
 		filteredRejections = Array.from(rejectedByPath.values());
 	}
+	// Rejections have no external side effect and must not depend on whether a
+	// selected-row notification succeeds.
+	if (filteredRejections.length) await markDeathsAsNo(env, filteredRejections);
 
 	let notified = 0;
 	if (options.beforeSideEffects) {
@@ -229,7 +232,6 @@ export async function applyLlmOutput(env: Env, outputText: string, candidatePath
 		for (const row of selectedRows) {
 			await updateDeathLLM(env, row.wiki_path, row.cause, row.description);
 		}
-		if (filteredRejections.length) await markDeathsAsNo(env, filteredRejections);
 		if (selectedRows.length) await options.beforeSideEffects();
 		for (const row of selectedRows) {
 			await notifySelectedRow(env, row);
@@ -243,7 +245,6 @@ export async function applyLlmOutput(env: Env, outputText: string, candidatePath
 			notified++;
 			await updateDeathLLM(env, row.wiki_path, row.cause, row.description);
 		}
-		if (filteredRejections.length) await markDeathsAsNo(env, filteredRejections);
 	}
 
 	return { notified, rejected: filteredRejections.length, errored: 0 } as const;

--- a/tests/llm-boundary.test.js
+++ b/tests/llm-boundary.test.js
@@ -12,7 +12,13 @@ const canonicalRow = {
 	cause: 'canonical cause',
 };
 
-function makeEnv({ failSubscriberRead = false } = {}) {
+const rejectedRow = {
+	...canonicalRow,
+	name: 'Rejected Person',
+	wiki_path: 'Rejected_Person',
+};
+
+function makeEnv({ deathRows = [canonicalRow], failSubscriberRead = false } = {}) {
 	const writes = [];
 	const reads = [];
 	const DB = {
@@ -22,7 +28,7 @@ function makeEnv({ failSubscriberRead = false } = {}) {
 					return {
 						async all() {
 							reads.push(sql);
-							if (sql.includes('FROM deaths')) return { results: [canonicalRow] };
+							if (sql.includes('FROM deaths')) return { results: deathRows };
 							if (sql.includes('FROM subscribers')) {
 								if (failSubscriberRead) throw new Error('notification lookup failed');
 								return { results: [] };
@@ -36,6 +42,9 @@ function makeEnv({ failSubscriberRead = false } = {}) {
 					};
 				},
 			};
+		},
+		async batch(statements) {
+			return Promise.all(statements.map((statement) => statement.run()));
 		},
 	};
 	return { env: { DB }, reads, writes };
@@ -107,6 +116,29 @@ test('synchronous send failures leave selected deaths pending for retry', async 
 		reads.some((sql) => sql.includes('FROM subscribers')),
 		true,
 	);
+	assert.equal(
+		writes.some((write) => write.sql.includes("llm_result = 'yes'")),
+		false,
+	);
+});
+
+test('synchronous send failures still persist independent rejections', async () => {
+	const { env, writes } = makeEnv({ deathRows: [canonicalRow, rejectedRow], failSubscriberRead: true });
+	await assert.rejects(
+		() =>
+			applyLlmOutput(
+				env,
+				JSON.stringify({
+					selected: [{ wiki_path: 'Trusted_Person' }],
+					rejected: [{ wiki_path: 'Rejected_Person', reason: 'Not notable' }],
+				}),
+				['Trusted_Person', 'Rejected_Person'],
+			),
+		/notification lookup failed/,
+	);
+	const rejectionUpdate = writes.find((write) => write.sql.includes("llm_result = 'no'"));
+	assert.ok(rejectionUpdate);
+	assert.deepEqual(rejectionUpdate.values, ['Not notable', 'Rejected_Person']);
 	assert.equal(
 		writes.some((write) => write.sql.includes("llm_result = 'yes'")),
 		false,

--- a/tests/llm-boundary.test.js
+++ b/tests/llm-boundary.test.js
@@ -12,7 +12,7 @@ const canonicalRow = {
 	cause: 'canonical cause',
 };
 
-function makeEnv() {
+function makeEnv({ failSubscriberRead = false } = {}) {
 	const writes = [];
 	const reads = [];
 	const DB = {
@@ -23,7 +23,10 @@ function makeEnv() {
 						async all() {
 							reads.push(sql);
 							if (sql.includes('FROM deaths')) return { results: [canonicalRow] };
-							if (sql.includes('FROM subscribers')) return { results: [] };
+							if (sql.includes('FROM subscribers')) {
+								if (failSubscriberRead) throw new Error('notification lookup failed');
+								return { results: [] };
+							}
 							return { results: [] };
 						},
 						async run() {
@@ -90,6 +93,22 @@ test('selected notifications do not start until the side-effect fence succeeds',
 	);
 	assert.equal(
 		reads.some((sql) => sql.includes('FROM subscribers')),
+		false,
+	);
+});
+
+test('synchronous send failures leave selected deaths pending for retry', async () => {
+	const { env, reads, writes } = makeEnv({ failSubscriberRead: true });
+	await assert.rejects(
+		() => applyLlmOutput(env, JSON.stringify({ selected: [{ wiki_path: 'Trusted_Person' }], rejected: [] }), ['Trusted_Person']),
+		/notification lookup failed/,
+	);
+	assert.equal(
+		reads.some((sql) => sql.includes('FROM subscribers')),
+		true,
+	);
+	assert.equal(
+		writes.some((write) => write.sql.includes("llm_result = 'yes'")),
 		false,
 	);
 });


### PR DESCRIPTION
## Summary

Addresses the unresolved review feedback from PR #39:

- preserve retryability for synchronous OpenAI evaluations by sending notifications before marking each selected death complete when no webhook fence exists
- retain the webhook path introduced by PR #39: persist D1 changes, complete the claim-token fence, then attempt external side effects
- add a regression test proving a synchronous notification-stage failure leaves the selected death pending

## Feedback handling

The repository owner requested review but provided no conflicting implementation guidance and did not ask to ignore any item.

Addressed: the unresolved retryability comment at https://github.com/brucehart/celebrity-death-bot/pull/39#discussion_r3573480970

Ignored feedback: none.

## Validation

- npm test (37 unit tests, 6 Workers-runtime tests)
- npx tsc --noEmit
- Prettier check
- git diff --cached --check

No schema or configuration changes are included.
