### PR TITLE
PR #40 feedback fixes

### DIFF
--- a/src/services/llm-output.ts
+++ b/src/services/llm-output.ts
@@ -220,6 +220,9 @@ export async function applyLlmOutput(env: Env, outputText: string, candidatePath
 		for (const item of rejectedItems) if (!selectedSet.has(item.wiki_path)) rejectedByPath.set(item.wiki_path, item);
 		filteredRejections = Array.from(rejectedByPath.values());
 	}
+	// Rejections have no external side effect and must not depend on whether a
+	// selected-row notification succeeds.
+	if (filteredRejections.length) await markDeathsAsNo(env, filteredRejections);
 
 	let notified = 0;
 	if (options.beforeSideEffects) {
@@ -229,7 +232,6 @@ export async function applyLlmOutput(env: Env, outputText: string, candidatePath
 		for (const row of selectedRows) {
 			await updateDeathLLM(env, row.wiki_path, row.cause, row.description);
 		}
-		if (filteredRejections.length) await markDeathsAsNo(env, filteredRejections);
 		if (selectedRows.length) await options.beforeSideEffects();
 		for (const row of selectedRows) {
 			await notifySelectedRow(env, row);
@@ -243,7 +245,6 @@ export async function applyLlmOutput(env: Env, outputText: string, candidatePath
 			notified++;
 			await updateDeathLLM(env, row.wiki_path, row.cause, row.description);
 		}
-		if (filteredRejections.length) await markDeathsAsNo(env, filteredRejections);
 	}
 
 	return { notified, rejected: filteredRejections.length, errored: 0 } as const;

--- a/tests/llm-boundary.test.js
+++ b/tests/llm-boundary.test.js
@@ -12,7 +12,13 @@ const canonicalRow = {
 	cause: 'canonical cause',
 };
 
-function makeEnv({ failSubscriberRead = false } = {}) {
+const rejectedRow = {
+	...canonicalRow,
+	name: 'Rejected Person',
+	wiki_path: 'Rejected_Person',
+};
+
+function makeEnv({ deathRows = [canonicalRow], failSubscriberRead = false } = {}) {
 	const writes = [];
 	const reads = [];
 	const DB = {
@@ -22,7 +28,7 @@ function makeEnv({ failSubscriberRead = false } = {}) {
 					return {
 						async all() {
 							reads.push(sql);
-							if (sql.includes('FROM deaths')) return { results: [canonicalRow] };
+							if (sql.includes('FROM deaths')) return { results: deathRows };
 							if (sql.includes('FROM subscribers')) {
 								if (failSubscriberRead) throw new Error('notification lookup failed');
 								return { results: [] };
@@ -36,6 +42,9 @@ function makeEnv({ failSubscriberRead = false } = {}) {
 					};
 				},
 			};
+		},
+		async batch(statements) {
+			return Promise.all(statements.map((statement) => statement.run()));
 		},
 	};
 	return { env: { DB }, reads, writes };
@@ -107,6 +116,29 @@ test('synchronous send failures leave selected deaths pending for retry', async 
 		reads.some((sql) => sql.includes('FROM subscribers')),
 		true,
 	);
+	assert.equal(
+		writes.some((write) => write.sql.includes("llm_result = 'yes'")),
+		false,
+	);
+});
+
+test('synchronous send failures still persist independent rejections', async () => {
+	const { env, writes } = makeEnv({ deathRows: [canonicalRow, rejectedRow], failSubscriberRead: true });
+	await assert.rejects(
+		() =>
+			applyLlmOutput(
+				env,
+				JSON.stringify({
+					selected: [{ wiki_path: 'Trusted_Person' }],
+					rejected: [{ wiki_path: 'Rejected_Person', reason: 'Not notable' }],
+				}),
+				['Trusted_Person', 'Rejected_Person'],
+			),
+		/notification lookup failed/,
+	);
+	const rejectionUpdate = writes.find((write) => write.sql.includes("llm_result = 'no'"));
+	assert.ok(rejectionUpdate);
+	assert.deepEqual(rejectionUpdate.values, ['Not notable', 'Rejected_Person']);
 	assert.equal(
 		writes.some((write) => write.sql.includes("llm_result = 'yes'")),
 		false,


### PR DESCRIPTION
## Summary

Addresses the unresolved review feedback from PR #40:

- persist filtered LLM rejections before either webhook or synchronous selected-row delivery begins
- keep synchronous selected rows pending when their notification path throws
- retain webhook persistence and claim-token fencing before external side effects
- add a mixed selected/rejected regression test proving independent rejections survive a selected notification failure

## Feedback handling

The repository owner requested review but provided no conflicting implementation guidance and did not ask to ignore any item.

Addressed: the unresolved rejection-persistence comment at https://github.com/brucehart/celebrity-death-bot/pull/40#discussion_r3573545041

Ignored feedback: none.

## Validation

- npm test (38 unit tests, 6 Workers-runtime tests)
- npx tsc --noEmit
- Prettier check
- git diff --cached --check

No schema or configuration changes are included.
